### PR TITLE
Extend block atlas to include TARDIS textures

### DIFF
--- a/assets/minecraft/atlases/blocks.json
+++ b/assets/minecraft/atlases/blocks.json
@@ -1,0 +1,24 @@
+{
+    "sources": [
+        {
+            "type": "directory",
+            "source": "dt",
+            "prefix": "dt/"
+        },
+        {
+            "type": "directory",
+            "source": "tardis",
+            "prefix": "tardis/"
+        },
+        {
+            "type": "directory",
+            "source": "glowing",
+            "prefix": "glowing/"
+        },
+        {
+            "type": "directory",
+            "source": "painting",
+            "prefix": "painting/"
+        }
+    ]
+}


### PR DESCRIPTION
needed due to block/item atlas changes made in 1.19.3 (22w42a)